### PR TITLE
feat: implement messages when launching the screenshot monitor

### DIFF
--- a/launch.sh
+++ b/launch.sh
@@ -9,7 +9,8 @@ BUTTON_LOG="$progdir/log/buttons.log"
 
 SERVICE_NAME="screenshot-monitor"
 HUMAN_READABLE_NAME="Screenshot Monitor"
-SUPPORTS_DAEMON_MODE=0
+ONLY_LAUNCH_THEN_EXIT=1
+LAUNCHES_SCRIPT="true"
 service_on() {
     cd "$SDCARD_PATH" || exit 1
     if [ -f "$progdir/log/service.log" ]; then
@@ -28,7 +29,16 @@ service_on() {
         hotkey="HOTKEY_1"
     fi
 
+    service_off
+
+    show_message "Enabling the $HUMAN_READABLE_NAME" 2
     PROGDIR="$progdir" HOTKEY="$hotkey" "$progdir/bin/screenshot-monitor" >"$progdir/log/service.log" 2>&1 &
+    if ! wait_for_service 10; then
+        show_message "Failed to start $HUMAN_READABLE_NAME" 2
+        return 1
+    fi
+
+    show_message "Started $HUMAN_READABLE_NAME" 2
 }
 
 service_off() {
@@ -130,11 +140,25 @@ wait_for_button() {
     done
 }
 
+is_service_running() {
+    if pgrep "$SERVICE_NAME" >/dev/null 2>&1; then
+        return 0
+    fi
+
+    if [ "$LAUNCHES_SCRIPT" = "true" ]; then
+        if pgrep -fn "$SERVICE_NAME" >/dev/null 2>&1; then
+            return 0
+        fi
+    fi
+
+    return 1
+}
+
 wait_for_service() {
     max_counter="$1"
     counter=0
 
-    while ! pgrep "$SERVICE_NAME" >/dev/null 2>&1; do
+    while ! is_service_running; do
         counter=$((counter + 1))
         if [ "$counter" -gt "$max_counter" ]; then
             return 1
@@ -145,7 +169,7 @@ wait_for_service() {
 
 main_daemonize() {
     echo "Toggling $SERVICE_NAME..."
-    if pgrep "$SERVICE_NAME"; then
+    if is_service_running; then
         show_message "Disabling the $HUMAN_READABLE_NAME" 2
         service_off
     else
@@ -162,7 +186,7 @@ main_daemonize() {
 }
 
 main_process() {
-    if pgrep "$SERVICE_NAME"; then
+    if is_service_running; then
         show_message "Disabling the $HUMAN_READABLE_NAME" 2
         service_off
     fi
@@ -190,7 +214,7 @@ main_process() {
 }
 
 main() {
-    if [ "$SUPPORTS_DAEMON_MODE" -eq 0 ]; then
+    if [ "$ONLY_LAUNCH_THEN_EXIT" -eq 1 ]; then
         service_on
         return $?
     fi


### PR DESCRIPTION
Instead of just exiting immediately, show a message stating that it is being launched, check if it is running, and then exit as appropriate.

Additionally, update process tracking to handle the case where we are launching a script - which doesn't respond as nicely to pgrep - vs a binary.

Finally, rename a variable to make it make more sense.